### PR TITLE
fix(hooks): set keyboard input method only after tab press

### DIFF
--- a/packages/hooks/src/useFocus/hook.ts
+++ b/packages/hooks/src/useFocus/hook.ts
@@ -5,8 +5,10 @@ export type InputMethod = 'keyboard' | 'mouse';
 
 let prevInputMethod: InputMethod;
 
-function handleKeyDown() {
-    prevInputMethod = 'keyboard';
+function handleKeyDown(event: KeyboardEvent) {
+    if (event.key === 'Tab') {
+        prevInputMethod = 'keyboard';
+    }
 }
 
 function handleMouseDown() {
@@ -28,7 +30,7 @@ function addGlobalListeners() {
 }
 
 /**
- * Хук устанавливает обработчик собития на focusin и focusout
+ * Хук устанавливает обработчик события на focusin и focusout
  * по конкретному типу события
  * @param node Элемент на котором установится обработчик (default = document)
  * @param inputMethod Если параметр не задан, установит обработчик по любому событию фокуса


### PR DESCRIPTION
# Кейс
Всплыл кейс, когда после заполнения одного поля, фокус программно переходит на другое поле.

# Ожидаемое поведение

Если первое поле до ввода было выбрано мышью — после перехода фокуса обводка не появляется

# Текущее поведение

Обводка появляется, т.к. последнее действие перед переходом фокуса было с клавиатуры (ввод в первое поле)

# Решение

Считаем, что с клавиатуры фокус может переходить только по нажатию таба