### PR TITLE
feat(hook): add useKeydownOutside

### DIFF
--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -33,6 +33,10 @@ https://github.com/facebook/react/issues/14099#issuecomment-440013892
 
 Подписка на событие `mousedown`, `touchstart`. При нажатии вне элемента вызывает переданный callback
 
+### useKeydownOutside
+
+Подписка на событие `keydown`. При нажатии вне элемента вызывает переданный callback
+
 ### useFocus
 
 Подписка на событие `focusin`, `focusout` для конкретного события фокуса (клавиатура/мышка).

--- a/packages/hooks/src/useKeydownOutside/hook.stories.tsx
+++ b/packages/hooks/src/useKeydownOutside/hook.stories.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+import { useKeydownOutside } from '.';
+
+export default { title: 'Hooks/useKeydownOutside' };
+
+const style: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    textTransform: 'uppercase',
+    color: 'white',
+    width: 300,
+    height: 300,
+    backgroundColor: 'coral',
+};
+
+const Component: React.FC = () => {
+    const ref = React.useRef(null);
+    useKeydownOutside(ref, action('outside keydown'));
+
+    return (
+        <div
+            ref={ ref }
+            style={ style }
+        >
+            Component area
+            <input type="text" />
+        </div>
+    );
+};
+
+export const Basic = () => (
+    <div>
+        <Component />
+        <input type="text" />
+    </div>
+);

--- a/packages/hooks/src/useKeydownOutside/hook.ts
+++ b/packages/hooks/src/useKeydownOutside/hook.ts
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export function useKeydownOutside(
+    ref: React.RefObject<HTMLElement>,
+    cb: (e: KeyboardEvent) => void,
+) {
+    React.useEffect(() => {
+        const handler = (event: KeyboardEvent) => {
+            if (!ref.current || (event.target instanceof Node && ref.current.contains(event.target))) {
+                return;
+            }
+
+            cb(event);
+        };
+
+        document.addEventListener('keydown', handler);
+
+        return () => {
+            document.removeEventListener('keydown', handler);
+        };
+    }, [ref, cb]);
+}

--- a/packages/hooks/src/useKeydownOutside/index.ts
+++ b/packages/hooks/src/useKeydownOutside/index.ts
@@ -1,0 +1,1 @@
+export * from './hook';


### PR DESCRIPTION
Перенес хук @raylyanway 
Хук подписывает на событие `keydown`. При нажатии вне элемента вызывает переданный callback