### PR TITLE
fix(currency-code): belarusian ruble

### DIFF
--- a/packages/data/src/currency/data.ts
+++ b/packages/data/src/currency/data.ts
@@ -7,7 +7,7 @@ const CURRENCY_SYMBOLS = {
     AZN: '\u20bc',
     BSD: '\u0024',
     BBD: '\u0024',
-    BYR: '\u0042\u0072',
+    BYN: '\u0042\u0072',
     BZD: '\u0042\u005a\u0024',
     BMD: '\u0024',
     BOB: '\u0024\u0062',


### PR DESCRIPTION
c 1 июля 2016 года используется код [BYN](https://wikipedia.tel/%D0%91%D0%B5%D0%BB%D0%BE%D1%80%D1%83%D1%81%D1%81%D0%BA%D0%B8%D0%B9_%D1%80%D1%83%D0%B1%D0%BB%D1%8C)