### PR TITLE
feat(utils): add format-file-size

### DIFF
--- a/packages/utils/src/format-file-size/index.ts
+++ b/packages/utils/src/format-file-size/index.ts
@@ -1,0 +1,1 @@
+export * from './util';

--- a/packages/utils/src/format-file-size/util.test.ts
+++ b/packages/utils/src/format-file-size/util.test.ts
@@ -2,6 +2,7 @@ import { formatFileSize } from './util';
 
 describe('formatFileSize', () => {
     const cases = [
+        ['10dd', '0 B'],
         [1, '1 B'],
         [10, '10 B'],
         [100, '100 B'],
@@ -16,6 +17,7 @@ describe('formatFileSize', () => {
         [100000000000, '93.13 GB'],
         [1000000000000, '99+ GB'],
         [10000000000000, '99+ GB'],
+        ['d10000000000000', '0 B'],
     ];
 
     it.each(cases)('formatFileSize(%i)', (fileSize, expected) => {

--- a/packages/utils/src/format-file-size/util.test.ts
+++ b/packages/utils/src/format-file-size/util.test.ts
@@ -1,0 +1,24 @@
+import { formatFileSize } from './util';
+
+describe('formatFileSize', () => {
+    const cases = [
+        [1, '1 B'],
+        [10, '10 B'],
+        [100, '100 B'],
+        [1000, '1000 B'],
+        [10000, '9.77 KB'],
+        [100000, '97.66 KB'],
+        [1000000, '976.56 KB'],
+        [10000000, '9.54 MB'],
+        [100000000, '95.37 MB'],
+        [1000000000, '953.67 MB'],
+        [10000000000, '9.31 GB'],
+        [100000000000, '93.13 GB'],
+        [1000000000000, '99+ GB'],
+        [10000000000000, '99+ GB'],
+    ];
+
+    it.each(cases)('formatFileSize(%i)', (fileSize, expected) => {
+        expect(formatFileSize(fileSize)).toBe(expected);
+    });
+});

--- a/packages/utils/src/format-file-size/util.ts
+++ b/packages/utils/src/format-file-size/util.ts
@@ -1,17 +1,19 @@
 const UNITS = ['B', 'KB', 'MB', 'GB'];
 
-const getStringHumanSize = (value: number, factor: number): string => {
+type FileSize = string | number;
+
+const humanizeNumberPartOfFileSize = (value: number, factor: number): string => {
     const maxFactor = UNITS.length - 1;
     if (value > 99 && factor === maxFactor) return '99+';
 
     return `${Number(value.toFixed(2))}`;
 };
 
-const getNumber = (value: string | number): number => {
-    const parsedValue = Number(value);
-    if (Number.isNaN(parsedValue)) return 0;
+const parseFileSize = (fileSize: FileSize): number => {
+    const parsedFileSize = Number(fileSize);
+    if (Number.isNaN(parsedFileSize)) return 0;
 
-    return parsedValue;
+    return parsedFileSize;
 };
 
 /**
@@ -23,11 +25,11 @@ const getNumber = (value: string | number): number => {
  * 1000 B,
  * 93.13 GB,
  * 99+ GB - Если файл превышает 99 GB,
- * 0 B - Если приходит строка не число
+ * 0 B - Если приходит строка, которую невозможно привести к числу
  */
-export const formatFileSize = (size: string | number): string => {
+export const formatFileSize = (fileSize: FileSize): string => {
     const maxFactor = UNITS.length - 1;
-    let humanSize: number = getNumber(size);
+    let humanSize: number = parseFileSize(fileSize);
     let factor = 0;
 
     while (humanSize >= 1024 && factor < maxFactor) {
@@ -35,5 +37,5 @@ export const formatFileSize = (size: string | number): string => {
         factor += 1;
     }
 
-    return `${getStringHumanSize(humanSize, factor)} ${UNITS[factor]}`;
+    return `${humanizeNumberPartOfFileSize(humanSize, factor)} ${UNITS[factor]}`;
 };

--- a/packages/utils/src/format-file-size/util.ts
+++ b/packages/utils/src/format-file-size/util.ts
@@ -7,9 +7,27 @@ const getStringHumanSize = (value: number, factor: number): string => {
     return `${Number(value.toFixed(2))}`;
 };
 
+const getNumber = (value: string | number): number => {
+    const parsedValue = Number(value);
+    if (Number.isNaN(parsedValue)) return 0;
+
+    return parsedValue;
+};
+
+/**
+ * Возвращает отформатированное значение размера файла.
+ * Разделяет пробелом число и единицу измерения.
+ *
+ * Примеры:
+ * 976.56 KB,
+ * 1000 B,
+ * 93.13 GB,
+ * 99+ GB - Если файл превышает 99 GB,
+ * 0 B - Если приходит строка не число
+ */
 export const formatFileSize = (size: string | number): string => {
     const maxFactor = UNITS.length - 1;
-    let humanSize: string | number = Number(size);
+    let humanSize: number = getNumber(size);
     let factor = 0;
 
     while (humanSize >= 1024 && factor < maxFactor) {

--- a/packages/utils/src/format-file-size/util.ts
+++ b/packages/utils/src/format-file-size/util.ts
@@ -1,0 +1,21 @@
+const UNITS = ['B', 'KB', 'MB', 'GB'];
+
+const getStringHumanSize = (value: number, factor: number): string => {
+    const maxFactor = UNITS.length - 1;
+    if (value > 99 && factor === maxFactor) return '99+';
+
+    return `${Number(value.toFixed(2))}`;
+};
+
+export const formatFileSize = (size: string | number): string => {
+    const maxFactor = UNITS.length - 1;
+    let humanSize: string | number = Number(size);
+    let factor = 0;
+
+    while (humanSize >= 1024 && factor < maxFactor) {
+        humanSize /= 1024;
+        factor += 1;
+    }
+
+    return `${getStringHumanSize(humanSize, factor)} ${UNITS[factor]}`;
+};


### PR DESCRIPTION
 Перенес утилиту для показа размера файла из https://github.com/alfa-laboratory/core-components/pull/571/files, так как можно ее будет переиспользовать где-то в других местах, например тут https://github.com/alfa-laboratory/core-components/issues/573 при выводе ошибки о разрешенном максимальном размере загружаемого файла.

@reme3d2y предложил показывать `99+ GB`, когда файл превышает 99 Гб. Но это на обсуждении, можно будет поменять :)