### PR TITLE
feat(utils): allow to use formatAmount without currency

### DIFF
--- a/packages/utils/src/format-amount/util.test.ts
+++ b/packages/utils/src/format-amount/util.test.ts
@@ -103,6 +103,21 @@ describe('formatAmount', () => {
         expect(formattedWithCurrency).toBe('123,45');
     });
 
+    it('should format correctly when currency is not passed', () => {
+        const {
+            majorPart, minorPart, formatted, formattedWithCurrency,
+        } = formatAmount({
+            view: 'default',
+            value: 12345,
+            minority: 100,
+        });
+
+        expect(majorPart).toBe('123');
+        expect(minorPart).toBe('45');
+        expect(formatted).toBe('123,45');
+        expect(formattedWithCurrency).toBe('123,45');
+    });
+
     it('should format correctly when passed null value and unknown currency', () => {
         const {
             majorPart, minorPart, formatted, formattedWithCurrency,

--- a/packages/utils/src/format-amount/util.ts
+++ b/packages/utils/src/format-amount/util.ts
@@ -18,7 +18,7 @@ type AmountType = {
     /**
      * Валюта
      */
-    currency: CurrencyCodes;
+    currency?: CurrencyCodes;
 
     /**
      * Количество минорных единиц в валюте
@@ -40,7 +40,7 @@ const formatWithCurrency = (value: string | null, currencySymbol?: string) =>
  * согласно гайдлайну https://design.alfabank.ru/patterns/amount
  */
 export const formatAmount = ({ value, currency, minority, view }: AmountType) => {
-    const currencySymbol = getCurrencySymbol(currency);
+    const currencySymbol = currency ? getCurrencySymbol(currency) : '';
 
     if (value === null) {
         return {


### PR DESCRIPTION
Очень большая потребность форматировать не только валюты, но и проценты, мили, баллы и пр. 
Утилита используется в компоненте Amount из кор. В Фижере компонент давал возможность выводить не только валюты. + название formatAmount хорошо подходит для этого.

Поэтому самым простым кажется сделать currency необязательным параметром 
