### PR TITLE
feat(use-click-outside): add ability to pass array

### DIFF
--- a/packages/hooks/src/useClickOutside/hook.ts
+++ b/packages/hooks/src/useClickOutside/hook.ts
@@ -1,18 +1,18 @@
-import { useEffect, RefObject, MouseEvent, TouchEvent } from 'react';
+import { useEffect, RefObject } from 'react';
 
 export function useClickOutside(
     ref: RefObject<HTMLElement> | Array<RefObject<HTMLElement>>,
     cb: (e: MouseEvent | TouchEvent) => void,
 ): void {
     useEffect(() => {
-        const handler = (event: any) => {
-            const clickedEl =
-                Array.isArray(ref) &&
-                ref.find((el) => !el.current || el.current.contains(event.target));
+        const handler = (event: MouseEvent | TouchEvent) => {
+            const checkClickedElement = (el: RefObject<HTMLElement>) =>
+                !el.current || el.current.contains(event.target as Element);
 
-            if (clickedEl) return;
-
-            if (!Array.isArray(ref) && (!ref.current || ref.current.contains(event.target))) {
+            if (
+                (Array.isArray(ref) && ref.find(checkClickedElement)) ||
+                (!Array.isArray(ref) && checkClickedElement(ref))
+            ) {
                 return;
             }
 

--- a/packages/hooks/src/useClickOutside/hook.ts
+++ b/packages/hooks/src/useClickOutside/hook.ts
@@ -1,12 +1,18 @@
-import React from 'react';
+import { useEffect, RefObject } from 'react';
 
 export function useClickOutside(
-    ref: React.RefObject<HTMLElement>,
-    cb: (e: React.MouseEvent | React.TouchEvent) => void,
+    ref: RefObject<HTMLElement> | Array<RefObject<HTMLElement>>,
+    cb: (e: MouseEvent | TouchEvent) => void,
 ): void {
-    React.useEffect(() => {
+    useEffect(() => {
         const handler = (event: any) => {
-            if (!ref.current || ref.current.contains(event.target)) {
+            const clickedEl =
+                Array.isArray(ref) &&
+                ref.find((el) => !el.current || el.current.contains(event.target));
+
+            if (clickedEl) return;
+
+            if (!Array.isArray(ref) && (!ref.current || ref.current.contains(event.target))) {
                 return;
             }
 

--- a/packages/hooks/src/useClickOutside/hook.ts
+++ b/packages/hooks/src/useClickOutside/hook.ts
@@ -1,4 +1,4 @@
-import { useEffect, RefObject } from 'react';
+import { useEffect, RefObject, MouseEvent, TouchEvent } from 'react';
 
 export function useClickOutside(
     ref: RefObject<HTMLElement> | Array<RefObject<HTMLElement>>,


### PR DESCRIPTION
В хук нельзя прокинуть несколько рефов, клик на которые будет не засчитываться.
Сделал доработку, теперь можно прокинуть как единственный реф, так и массив рефов.
Еще убрал импорт всего реакта и добавил импорт только нужных хуков и типов.