### PR TITLE
feat(currency): updated CNY symbol

### DIFF
--- a/packages/data/src/currency/data.ts
+++ b/packages/data/src/currency/data.ts
@@ -20,7 +20,7 @@ const CURRENCY_SYMBOLS = {
     CAD: '\u0043\u0024',
     KYD: '\u0024',
     CLP: '\u0024',
-    CNY: '\u00a5',
+    CNY: '\u5143',
     COP: '\u0024',
     CRC: '\u20a1',
     HRK: '\u006b\u006e',


### PR DESCRIPTION
Use 元 as primary symbol for CNY currency,
Полина Шагалиева is requesting this change